### PR TITLE
Update TutorialTest in CMake to use relative binary directory

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,5 +2,5 @@ include_directories(${tutorial_INCDIR})
 
 add_executable(tutorial_test tutorial_test.cpp)
 target_link_libraries(tutorial_test tutorial gtest_main)
-add_test(TutorialTest mpirun -n 4 ./tutorial_test)
+add_test(TutorialTest mpirun -n 4 ${CMAKE_BINARY_DIR}/bin/tutorial_test)
 


### PR DESCRIPTION
placing tutorial_test in the test output directory required significant high-skill CMake to bypass directory routing.
This PR tells the test generator to locate the tutorial_test executable relative to the binary build directory, which is set by default.